### PR TITLE
Build: Write each project+platform combo to a separate folder once again

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,8 @@ function get_out {
 	local TARGET_PROJECT="$2"
 	local BASE_DIR="$3"
 
-	local TARGET_OUT="${BASE_DIR}/VDF-${TARGET_PLATFORM}"
+	local TARGET_OUT="${TARGET_PROJECT/VideoDuplicateFinder/VDF}"
+	local TARGET_OUT="${BASE_DIR}/${TARGET_OUT}-${TARGET_PLATFORM}"
 	echo "$TARGET_OUT"
 }
 
@@ -36,19 +37,21 @@ PLATFORM=win-x64
 PROJECTS=("VideoDuplicateFinder.Windows" "VideoDuplicateFinder.Web" "VideoDuplicateFinder.Console")
 BASE_DIR="Releases"
 
+rm -r $BASE_DIR/VDF*
+
 for project in ${PROJECTS[@]}; do
 	echo "Building $PLATFORM $project"
 	TARGET_OUT="$(get_out $TARGET_PLATFORM $TARGET_PROJECT $BASE_DIR)"
 	publish "$PLATFORM" "$project" "$BASE_DIR"
 
+	if [[ -d "$BASE_DIR/ffmpeg" ]]; then
+		mkdir -p "${TARGET_OUT}/bin/"
+		cp ${BASE_DIR}/ffmpeg/x64/*.* "${TARGET_OUT}/bin/"
+		
+	fi
 
 done
 
-if [[ -d "$BASE_DIR/ffmpeg" ]]; then
-	mkdir -p "${TARGET_OUT}/bin/"
-	cp ${BASE_DIR}/ffmpeg/x64/*.* "${TARGET_OUT}/bin/"
-	
-fi
 
 PLATFORM=linux-x64
 PROJECTS=("VideoDuplicateFinderLinux" "VideoDuplicateFinder.Web" "VideoDuplicateFinder.Console")


### PR DESCRIPTION
Previously it seemed to work okay to write all binaries for a platform
to same folder, but now this doesn't work.

It's possible ASP.net runtime binaries aren't compatible with regular
runtime binaries, I don't know.